### PR TITLE
fix: heroku deployment

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,3 @@
+# https://devcenter.heroku.com/articles/java-support#supported-java-versions
+java.runtime.version=17
+maven.version=3.9.5


### PR DESCRIPTION
Heroku is running Java 1.8 by default ([here](https://devcenter.heroku.com/articles/java-support#specifying-a-java-version)). So I added `system.properties` where is proper Java settings specified.