### PR TITLE
feat: update dependencies for Spring Boot and ButterCMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - 2025-03-17
+
+### Changed
+- Update Spring Boot from 3.1.4 to 3.2.3 (latest LTS)
+- Update ButterCMS client from 1.11 to 1.12.0
+- Add explicit Jackson dependencies with version 2.15.3 to fix compatibility issues
+- Add OWASP dependency check plugin for security monitoring
+- Add SnakeYAML override to ensure latest secure version
+- Update README with installation instructions for Ubuntu and macOS
+
+### Added
+- Added semantic versioning (first official versioned release)
+- Added version and Spring Boot badges to README
+- Created CHANGELOG.md
+
+## [0.0.1-SNAPSHOT] - 2023-10-04
+
+### Added
+- Initial project setup
+- Spring Boot 3.1.4 with Java 17
+- ButterCMS integration
+- Blog and landing page functionality
+- Thymeleaf templates for rendering pages

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo apt install maven
 ```bash
 # Using Homebrew
 brew install --cask temurin@17
-# Using Homebrew
+# Install Maven
 brew install maven
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Java version](https://img.shields.io/badge/Java-17-red)
+![Java version](https://img.shields.io/badge/Java-17-red) ![Version](https://img.shields.io/badge/Version-1.3.0-blue) ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.2.3-green)
 
 # Java Spring Boot +  ButterCMS Starter Project
 
@@ -20,9 +20,26 @@ to deploy your own copy of our starter project to the provider of your  choice.
 
 This project requires Java 17 and Maven. All other dependencies (Spring Boot, Java SDK for ButterCMS) are automatically managed by Maven.
 
+#### Installing Java 17 and Maven on Ubuntu
+```bash
+# Update package list and install OpenJDK 17
+sudo apt update && sudo apt install openjdk-17-jdk
+# Install Maven
+sudo apt install maven
+```
+
+#### Installing Java 17 and Maven on macOS
+```bash
+# Using Homebrew
+brew tap homebrew/cask-versions
+brew install --cask temurin17
+# Using Homebrew
+brew install maven
+```
+
 To get started, clone and cd into the repo.
 
-```
+```bash
 git clone https://github.com/ButterCMS/java-starter-buttercms.git
 cd java-starter-buttercms
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cd java-starter-buttercms
 To fetch your ButterCMS content, add your API token as an environment variable.
 
 ```bash
-$ echo 'JAVA_BUTTER_CMS_API_KEY=<Your API Token>' >> .env`
+$ echo 'JAVA_BUTTER_CMS_API_KEY=<Your API Token>' >> .env
 ```
 
 ### 3. Build the project

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ sudo apt install maven
 #### Installing Java 17 and Maven on macOS
 ```bash
 # Using Homebrew
-brew tap homebrew/cask-versions
-brew install --cask temurin17
+brew install --cask temurin@17
 # Using Homebrew
 brew install maven
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,16 +5,17 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.4</version>
+        <version>3.2.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.buttercms</groupId>
     <artifactId>spring-starter-buttercms</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.3.0</version>
     <name>spring-starter-buttercms</name>
     <description>spring-starter-buttercms</description>
     <properties>
         <java.version>17</java.version>
+        <jackson.version>2.15.3</jackson.version>
     </properties>
     <dependencies>
         <dependency>
@@ -33,9 +34,36 @@
         <dependency>
             <groupId>com.buttercms</groupId>
             <artifactId>buttercmsclient</artifactId>
-            <version>1.11</version>
+            <version>1.12.0</version>
+        </dependency>
+        <!-- Explicit Jackson dependencies for compatibility -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force transitive dependencies to latest versions -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>
@@ -43,7 +71,18 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>8.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
- Update Spring Boot from 3.1.4 to 3.2.3 (latest LTS)
- Update ButterCMS client from 1.11 to 1.12.0
- Add explicit Jackson dependencies with version 2.15.3 to fix compatibility issue
- Add OWASP dependency check plugin for security monitoring
- Add SnakeYAML override to ensure latest secure version
- Set project version to 1.3.0 in pom.xml
- Add version and Spring Boot badges to README
- Create CHANGELOG.md to track version history
- Implement semantic versioning strategy for the project