### PR TITLE
Add  -DskipTests to mvn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ echo 'JAVA_BUTTER_CMS_API_KEY=<Your API Token>' >> .env
 Build the project with the following command
 
 ```bash
-$ mvn install
+$ mvn install -DskipTests
 ```
 
 ### 4. Run the project


### PR DESCRIPTION
https://tiugotech.atlassian.net/browse/BCMS-772

The onboarding instructions on /home and the README.md contain different commands for building the Java starter project:
• /home:
mvn install -DskipTests

• README.md:
mvn install

This inconsistency can be confusing to users, especially if the tests fail due to local environment issues. For consistency and smoother onboarding, it would be better to align both instructions.