### PR TITLE
Add localhost output after running mvn spring-boot:run

### DIFF
--- a/src/main/java/com/buttercms/springstarterbuttercms/SpringStarterButtercmsApplication.java
+++ b/src/main/java/com/buttercms/springstarterbuttercms/SpringStarterButtercmsApplication.java
@@ -2,12 +2,19 @@ package com.buttercms.springstarterbuttercms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
 
 @SpringBootApplication
 public class SpringStarterButtercmsApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(SpringStarterButtercmsApplication.class, args);
+        var context = SpringApplication.run(SpringStarterButtercmsApplication.class, args);
+
+        // Get the port
+        if (context instanceof ServletWebServerApplicationContext webContext) {
+            int port = webContext.getWebServer().getPort();
+            System.out.println("Application running on port: " + port);
+        }
     }
 
 }


### PR DESCRIPTION
https://tiugotech.atlassian.net/browse/BCMS-772
Missing localhost output after running mvn spring-boot:run
After running the command:
mvn spring-boot:run

the application starts successfully on port 8080, but no confirmation message or localhost URL is printed to the terminal. New users may not know where to access the app.
A console message such as:

ButterCMS starter is running at: http://localhost:8080

would improve visibility and match the onboarding experience of other ButterCMS starter projects (e.g., Astro, ExpressJS).